### PR TITLE
Refactor: Hide clear cart button and cart count on empty cart

### DIFF
--- a/src/components/Cart.js
+++ b/src/components/Cart.js
@@ -19,23 +19,25 @@ const Cart = () => {
 
   return (
     <div className="md:w-3/5 w-[80%]  m-auto py-4 min-h-screen ">
-      <div className="flex justify-between items-center mb-4">
-        <h1 className="text-2xl font-semibold">Cart - {cartItems.length}</h1>
-        <button
-          className="text-xs font-medium bg-orange-300 py-1 px-2 hover:bg-orange-200 transition-all duration-300 ease-in-out rounded"
-          onClick={() => HandleClearCart()}
-        >
-          Clear Cart
-        </button>
-      </div>
       {cartItems.length > 0 ? (
-        <div className="flex flex-col ">
-          {cartItems.map((item) => {
-            return (
-              <CartItem key={item?.info?.id} {...item?.info} />
-            );
-          })}
-        </div>
+        <>
+          <div className="flex justify-between items-center mb-4">
+            <h1 className="text-2xl font-semibold">Cart - {cartItems.length}</h1>
+            <button
+              className="text-xs font-medium bg-orange-300 py-1 px-2 hover:bg-orange-200 transition-all duration-300 ease-in-out rounded"
+              onClick={() => HandleClearCart()}
+            >
+              Clear Cart
+            </button>
+          </div>
+          <div className="flex flex-col ">
+            {cartItems.map((item) => {
+              return (
+                <CartItem key={item?.info?.id} {...item?.info} />
+              );
+            })}
+          </div>
+        </>
       ) : (
         <EmptyCart />
       )}


### PR DESCRIPTION
This pr refactors the code to hide 'clear cart' button and cart count when cart is empty.

**When cart is empty**
![image](https://github.com/Anandsg/Hungry-hero/assets/59774795/cd6ca1f1-eca0-4897-9252-bdc383efa054)

**When cart contains items**
![image](https://github.com/Anandsg/Hungry-hero/assets/59774795/ac0a26fb-0f26-4ae8-b222-db5eceeda06e)
