### PR TITLE
Align search bar to center for md screen size #101

### DIFF
--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -106,8 +106,8 @@ const Body = () => {
             </button>
           </div>
         ) : (
-          <>
-            <div className="flex flex-col md:flex-row items-center md:pl-96  md:items-centre md:pl-9">
+          <div className="lg:block md:flex md:justify-center">
+            <div className="flex flex-col md:flex-row items-center lg:pl-96  md:items-center lg:pl-9">
               <div className="flex items-center ">
                 <input
                   type="text"
@@ -171,7 +171,7 @@ const Body = () => {
                 </span>
               </div>
             </div>
-          </>
+          </div>
         )}
       </div>
       <div>


### PR DESCRIPTION
This PR fixes #101 

Screenshots of the fixed search bar
<img width="998" alt="Screenshot 2023-10-07 at 2 11 21 PM" src="https://github.com/Anandsg/Hungry-hero/assets/77829767/9222967b-610d-48a1-a5c9-cf63f7287ee6">

<img width="998" alt="Screenshot 2023-10-07 at 2 11 32 PM" src="https://github.com/Anandsg/Hungry-hero/assets/77829767/9b11542b-0926-497f-8140-962d75bdce24">


