### PR TITLE
fix: modified contributors-interaction with necessary permissions

### DIFF
--- a/.github/workflows/contributor-interaction.yml
+++ b/.github/workflows/contributor-interaction.yml
@@ -6,6 +6,10 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  issues: write # Define permissions for issues
+  pull-requests: write # Define permissions for pull requests
+
 jobs:
   greet_contributors:
     runs-on: ubuntu-latest


### PR DESCRIPTION
fixes #267 

This will fix the bug of contributors workflow as I've updated it with necessary permission setting.